### PR TITLE
Remove unused imports

### DIFF
--- a/init_django/cli_common.py
+++ b/init_django/cli_common.py
@@ -2,15 +2,15 @@
 Funções utilitárias e lógica compartilhada entre interfaces CLI (usuário e MCP).
 Sempre que um comando for adicionado ou alterado, garanta que ambos cli_user.py e cli_mcp.py estejam compatíveis com a mesma API e semântica.
 """
-import os
+
+import json
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
-from shutil import copyfile
 from typing import Any, Dict, Optional
 
 import click
-import json
-from datetime import datetime, timezone
+
 
 def run(cmd: str, check: bool = True) -> None:
     """Run a shell command and echo its output.
@@ -43,6 +43,7 @@ def run(cmd: str, check: bool = True) -> None:
             click.echo("[stderr]", err=True)
             click.echo(e.stderr, err=True)
         raise
+
 
 def emit_json_event(
     event: str,
@@ -77,6 +78,7 @@ def emit_json_event(
     if error_code:
         obj["error_code"] = error_code
     print(json.dumps(obj), flush=True)
+
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 


### PR DESCRIPTION
## Summary
- delete unused imports in `init_django/cli_common.py`
- run flake8 to confirm no unused-import warnings

## Testing
- `flake8 init_django/cli_common.py`

------
https://chatgpt.com/codex/tasks/task_e_686b43aa2b68832480bf2f22a05b56b6