### PR TITLE
Translate CLI docstrings and messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,20 +63,20 @@ Sample JSON output:
 - Use the JSON mode for all agent, MCP, or CI/CD integrations.
 - See `docs/mcps_documentation.md` for advanced integration and event schema.
 
-## Integração com MCPs (Multi-Component Platforms/AI agents)
+## MCP Integration (Multi-Component Platforms/AI agents)
 
-O CLI Tribeca Django Init está sendo planejado para uso facilitado por agentes inteligentes e automação. Veja detalhes, exemplos e melhores práticas em [`docs/mcps_documentation.md`](docs/mcps_documentation.md).
+The Tribeca Django Init CLI is being designed for streamlined use by intelligent agents and automation. See details, examples, and best practices in [`docs/mcps_documentation.md`](docs/mcps_documentation.md).
 
 ## Settings Templates Architecture (2025)
 
-- **Motivação:** Para garantir clareza, manutenção e alinhamento com as melhores práticas Django, os templates de settings agora ficam em `init_django/templates/settings/`.
-- **Arquivos:**
-  - `base.py.tpl`, `dev.py.tpl`, `prod.py.tpl` (geram os arquivos finais em `config/settings/`)
-- **Vantagens:**
-  - Facilita a busca e manutenção dos templates.
-  - Permite adicionar outros templates de settings ou ambientes facilmente.
-  - Fica alinhado com o padrão Django e projetos modernos.
-  - Torna o fluxo do CLI e a documentação mais previsíveis para humanos e IAs.
+- **Motivation:** To ensure clarity, maintainability, and alignment with Django best practices, the settings templates now reside in `init_django/templates/settings/`.
+- **Files:**
+  - `base.py.tpl`, `dev.py.tpl`, `prod.py.tpl` (generate the final files in `config/settings/`)
+- **Advantages:**
+  - Makes it easy to locate and maintain the templates.
+  - Allows other settings templates or environments to be added easily.
+  - Aligns with the Django standard and modern projects.
+  - Makes the CLI flow and documentation more predictable for humans and AIs.
 
 ## Example of Update Log
 

--- a/init_django/cli_common.py
+++ b/init_django/cli_common.py
@@ -1,6 +1,5 @@
-"""
-Funções utilitárias e lógica compartilhada entre interfaces CLI (usuário e MCP).
-Sempre que um comando for adicionado ou alterado, garanta que ambos cli_user.py e cli_mcp.py estejam compatíveis com a mesma API e semântica.
+"""Utility functions and shared logic for both CLI interfaces (user and MCP).
+Whenever a command is added or modified, ensure ``cli_user.py`` and ``cli_mcp.py`` remain compatible with the same API and semantics.
 """
 import os
 import subprocess
@@ -80,4 +79,4 @@ def emit_json_event(
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
-# Outras funções utilitárias compartilhadas podem ser adicionadas aqui.
+# Additional shared utility functions can be added here.

--- a/init_django/cli_mcp.py
+++ b/init_django/cli_mcp.py
@@ -1,6 +1,5 @@
-"""
-Interface CLI para MCPs/agentes (modo não-interativo, argumentos/flags, saída JSON).
-Sempre mantenha compatibilidade de comandos e semântica com cli_user.py.
+"""CLI interface for MCPs/agents (non-interactive, arguments/flags, JSON output).
+Always keep command compatibility and semantics in sync with ``cli_user.py``.
 """
 import sys
 from pathlib import Path
@@ -23,14 +22,12 @@ from shutil import copyfile
 @click.option('--migrate', type=click.Choice(['yes', 'no']), default=None)
 @click.option('--readme', type=click.Choice(['yes', 'no']), default=None)
 def main(json_mode, venv, install_deps, django_version, git_init, project, settings, app_name, app_create, migrate, readme):
-    """
-    CLI MCP/Agente: modo não-interativo, argumentos/flags, saída JSON.
-    """
+    """MCP/agent CLI: non-interactive, argument-driven, emits JSON."""
     try:
         print_install_success()
         base = Path.cwd()
         venv_path = base / ".venv"
-        emit_json_event("start", "success", "Bootstrap iniciado", {"cwd": str(base)})
+        emit_json_event("start", "success", "Bootstrap started", {"cwd": str(base)})
 
         # 1️⃣ Virtual environment
         venv_action = venv or 'reuse' if venv_path.exists() else 'recreate'
@@ -76,7 +73,7 @@ def main(json_mode, venv, install_deps, django_version, git_init, project, setti
         else:
             emit_json_event("git", "skipped", "Git initialization skipped", {})
 
-        # 4. Projeto Django
+        # 4. Django project
         if (base / "manage.py").exists():
             emit_json_event("project", "success", "Django project already exists", {})
         elif project == 'yes':
@@ -125,7 +122,7 @@ def main(json_mode, venv, install_deps, django_version, git_init, project, setti
                 emit_json_event("readme", "skipped", "Skipped README creation", {})
         else:
             emit_json_event("project", "skipped", "Skipped Django project creation", {})
-        emit_json_event("done", "success", "Projeto inicializado/interativo concluído", {"project_root": str(base.resolve())})
+        emit_json_event("done", "success", "Project initialization/interactive flow completed", {"project_root": str(base.resolve())})
     except Exception as e:
         import traceback
         emit_json_event("error", "error", f"Error: {e}", {"traceback": traceback.format_exc()}, error_code="UNHANDLED_EXCEPTION")

--- a/init_django/cli_user.py
+++ b/init_django/cli_user.py
@@ -1,6 +1,5 @@
-"""
-Interface CLI tradicional (usuário humano, prompts interativos).
-Sempre mantenha compatibilidade de comandos e semântica com cli_mcp.py.
+"""Traditional CLI interface for human users with interactive prompts.
+Always keep command compatibility and semantics in sync with ``cli_mcp.py``.
 """
 import sys
 from pathlib import Path
@@ -12,13 +11,11 @@ from shutil import copyfile
 
 @click.command()
 def main():
-    """
-    CLI interativo para bootstrap de projetos Django seguindo convenções profissionais.
-    """
+    """Interactive CLI to bootstrap Django projects following best practices."""
     print_install_success()
     base = Path.cwd()
     venv = base / ".venv"
-    click.echo("\nTribeca Django Init — Bootstrap interativo Django\n")
+    click.echo("\nTribeca Django Init — Interactive Django Bootstrap\n")
 
     # 1️⃣ Virtual environment
     click.echo("\n🌱  Step 1: Virtual Environment Setup")
@@ -87,7 +84,7 @@ def main():
 
     # 3. Git
     if (base / ".git").exists():
-        click.echo("Repositório Git já inicializado.")
+        click.echo("Git repository already initialized.")
     else:
         git_choice = click.prompt(
             "3️⃣  Git repository setup\n1\u20e3  Initialize git repository\n2\u20e3  Skip this step\nEnter your choice:",
@@ -101,9 +98,9 @@ def main():
         else:
             click.echo("Skipping git initialization.")
 
-    # 4. Projeto Django
+    # 4. Django project
     if (base / "manage.py").exists():
-        click.echo("Projeto Django já existe nesta pasta.")
+        click.echo("Django project already exists in this folder.")
     else:
         proj_choice = click.prompt(
             "4️⃣  Django project setup\n1\u20e3  Create Django project (config)\n2\u20e3  Skip this step\nEnter your choice:",
@@ -116,11 +113,11 @@ def main():
             req_target = base / "requirements.txt"
             if req_tpl.exists() and not req_target.exists():
                 copyfile(req_tpl, req_target)
-                click.echo("requirements.txt criado a partir do template.")
+                click.echo("requirements.txt created from template.")
 
             settings_dir = base / "config" / "settings"
             if settings_dir.exists():
-                click.echo("Pacote de settings já existe.")
+                click.echo("Settings package already exists.")
             else:
                 settings_choice = click.prompt(
                     "5️⃣  Settings package setup\n1️⃣  Create settings package (config/settings)\n2️⃣  Skip this step\nEnter your choice:",
@@ -140,9 +137,9 @@ def main():
                 else:
                     click.echo("Skipping settings package creation.")
 
-            app_name = click.prompt("Nome do primeiro app (ex: users)", default="users")
+            app_name = click.prompt("Name of the first app (e.g., users)", default="users")
             if (base / app_name).exists():
-                click.echo(f"App '{app_name}' já existe.")
+                click.echo(f"App '{app_name}' already exists.")
             else:
                 app_choice = click.prompt(
                     f"6️⃣  App creation\n1️⃣  Create app '{app_name}'\n2️⃣  Skip this step\nEnter your choice:",
@@ -164,11 +161,11 @@ def main():
                     click.echo(f"Skipping creation of app '{app_name}'.")
 
             if (base / "README.md").exists():
-                click.echo("README.md já existe.")
+                click.echo("README.md already exists.")
             else:
                 copyfile(TEMPLATES_DIR / "readme.md.tpl", base / "README.md")
-                click.echo("README.md criado a partir do template.")
+                click.echo("README.md created from template.")
         else:
             click.echo("Skipping Django project creation.")
 
-    click.echo(f"\n✅ Projeto inicializado/interativo concluído em {base.resolve()}\n")
+    click.echo(f"\n✅ Project initialization/interactive flow completed in {base.resolve()}\n")


### PR DESCRIPTION
## Summary
- switch CLI module docstrings and comments to English
- translate user-facing messages in `cli_user.py` and `cli_mcp.py`
- translate guidance sections in AGENTS.md to English

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b43b265508324806d3076cee4d3d8