### PR TITLE
Add flake8 config with 88 char limit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/init_django/cli.py
+++ b/init_django/cli.py
@@ -3,6 +3,7 @@ Entrypoint CLI para o Tribeca Django Init.
 Detecta modo MCP (argumentos/flags ou --json) e delega para a interface correta.
 Sempre mantenha cli_user.py e cli_mcp.py compatíveis com os mesmos comandos e semântica.
 """
+
 import sys
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `.flake8` with max line length 88
- run `pre-commit run --files init_django/cli.py`

## Testing
- `pre-commit run --files init_django/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_686b4872a02883248a78a597681c2a2c