### PR TITLE
Translate docs to English

### DIFF
--- a/docs/mcps_documentation.md
+++ b/docs/mcps_documentation.md
@@ -1,44 +1,41 @@
-# Integração com MCPs (Multi-Component Platforms/AI Agents)
+# Integration with MCPs (Multi-Component Platforms / AI Agents)
 
-Este documento detalha como tornar o Tribeca Django Init CLI totalmente compatível, automatizável e amigável para plataformas MCPs e agentes de IA.
+This guide explains how to make the Tribeca Django Init CLI fully automation friendly and suitable for AI agents and other platforms.
 
-## Visão Geral
-O CLI Tribeca Django Init está sendo planejado e evoluído para uso não apenas por humanos, mas também por agentes inteligentes e plataformas de automação (MCPs). Isso inclui:
-- Execução não-interativa via argumentos/flags
-- Prompts e saídas estruturadas e padronizadas
-- Documentação clara para integração
-- Testes automatizados para ambos os modos (humano e MCP/JSON), garantindo robustez para integração com agentes e automação
+## Overview
+The CLI is designed for both humans and intelligent automation tools. Key goals include:
+- Non‑interactive execution through flags and arguments
+- Predictable, structured prompts and output
+- Clear documentation for third‑party integration
+- Automated tests covering both human and JSON/MCP modes
 
-## Arquitetura CLI: Interface Humana e MCP
+## CLI Architecture: Human and MCP Interfaces
+The Tribeca Django Init CLI offers two synchronized entry points:
 
-O Tribeca Django Init CLI possui duas interfaces totalmente sincronizadas:
+- `cli_user.py`: traditional interactive mode with friendly prompts
+- `cli_mcp.py`: non‑interactive mode that accepts flags and produces JSON output
+- All utility and business logic lives in `cli_common.py` so both modes share the same API and semantics
 
-- `cli_user.py`: interface tradicional para humanos, com prompts interativos, mensagens amigáveis e UX aprimorada.
-- `cli_mcp.py`: interface para MCPs/agentes/automação, modo não-interativo, argumentos/flags e saída padronizada JSON.
-- Toda a lógica utilitária e de negócio reside em `cli_common.py`, garantindo que ambos os modos compartilhem a mesma API e semântica.
+**Important**: whenever a new feature or command is added, it must exist in both interfaces (`cli_user.py` and `cli_mcp.py`).
 
-**IMPORTANTE:**
-Sempre que uma nova feature, comando ou ajuste for implementado, garanta que a funcionalidade seja replicada e compatível em ambos os arquivos (`cli_user.py` e `cli_mcp.py`).
+- `cli.py` detects which mode to run and delegates accordingly
+- Both interfaces accept the same commands and options; only the interaction style changes
+- Tests and documentation must cover both modes
 
-- O entrypoint (`cli.py`) detecta o modo automaticamente e delega para o arquivo correto.
-- Ambas as interfaces devem aceitar os mesmos comandos, argumentos e fluxos, apenas mudando a forma de interação (prompts vs flags/JSON).
-- Testes e documentação devem cobrir ambos os modos.
+## JSON Mode (`--json`)
+When the `--json` flag is provided, the CLI emits structured JSON describing each step. This allows easy parsing by automation tools.
 
-## Modo JSON (--json)
-
-Para integração avançada com MCPs, o CLI suporta o argumento `--json`, que faz com que todas as saídas relevantes do CLI sejam emitidas em formato JSON estruturado, facilitando o parsing por agentes e scripts automatizados.
-
-### Exemplo de uso
+### Example usage
 ```bash
 tribeca-django-init ... --json
 ```
 
-### Exemplo de saída JSON
+### Example JSON output
 ```json
 {
   "step": "virtualenv",
   "status": "created",
-  "path": "/home/user/projeto/.venv"
+  "path": "/home/user/project/.venv"
 }
 {
   "step": "dependencies",
@@ -53,44 +50,45 @@ tribeca-django-init ... --json
 {
   "step": "done",
   "status": "success",
-  "project_root": "/home/user/projeto"
+  "project_root": "/home/user/project"
 }
 ```
 
-- Cada etapa relevante do CLI gera um objeto JSON na saída padrão.
-- Em caso de erro, um objeto JSON com `status: error` e mensagem detalhada é emitido.
-- Ideal para integração com MCPs, CI/CD, scripts e plataformas de agentes inteligentes.
+- Each relevant step outputs a JSON object
+- On error, a JSON object with `status: error` and a message is produced
+- Ideal for MCPs, CI/CD pipelines, and intelligent agents
 
-## Roadmap e Features Planejadas
+## Roadmap and Planned Features
 
-### 1. Modo Não-Interativo/Automatizável
-- Permitir execução do CLI com todos os parâmetros via argumentos de linha de comando (ex: `--language-code`, `--timezone`, `--no-input`, etc.)
-- Exemplo:
+### 1. Non‑Interactive / Automatable Mode
+- Allow running the CLI entirely via command‑line flags (e.g. `--language-code`, `--timezone`, `--no-input`)
+- Example:
   ```bash
-  tribeca-django-init --language-code pt-br --second-language en --timezone America/Sao_Paulo --no-input
+  tribeca-django-init --language-code en --second-language pt-br --timezone America/Sao_Paulo --no-input
   ```
 
-### 2. Prompts e Saídas Estruturadas
-- Garantir que todos os prompts e saídas do CLI sejam claros, previsíveis e facilmente parseáveis por scripts e agentes.
-- Opcional: saída em JSON ou modo "machine-friendly".
+### 2. Structured Prompts and Output
+- Ensure prompts and CLI output are clear and easily parsed
+- Optional: provide JSON or other machine‑friendly output formats
 
-### 3. Documentação para Agentes/MCPs
-- Seção dedicada no README e AGENTS.md sobre integração com MCPs
-- Exemplos de automação (scripts, pipelines CI/CD, integração com plataformas de agentes)
+### 3. Documentation for Agents/MCPs
+- Dedicated sections in `README` and `AGENTS.md` showing integration examples
+- Automation snippets, CI/CD pipelines, and agent workflows
 
-### 4. Testes Automatizados para Uso por Agentes/MCPs
-- Testes que garantam funcionamento do CLI em ambientes headless, CI/CD e automação
-- Testes de idempotência e robustez
+### 4. Automated Tests for Agent Use
+- Tests that verify the CLI works in headless or CI environments
+- Idempotency and robustness checks
 
-### 5. Boas Práticas de Integração
-- Recomendações para integração segura e previsível em pipelines
-- Sugestão de padrões de resposta e tratamento de erros
-
----
-
-## Referência na Documentação
-> O suporte e compatibilidade com MCPs já está em planejamento ativo. Veja também o backlog e a seção "IA, Automação e MCPs" para detalhes e progresso.
+### 5. Integration Best Practices
+- Recommendations for safe integration in pipelines
+- Suggested patterns for responses and error handling
 
 ---
 
-Sinta-se à vontade para contribuir com sugestões, exemplos ou abrir issues sobre integração com MCPs!
+## Documentation Reference
+Support for MCPs is under active development. See the backlog and the "AI, Automation and MCPs" section for progress.
+
+---
+
+Feel free to contribute ideas, examples, or open issues about MCP integration!
+

--- a/init_django/cli.py
+++ b/init_django/cli.py
@@ -1,16 +1,19 @@
-"""
-Entrypoint CLI para o Tribeca Django Init.
-Detecta modo MCP (argumentos/flags ou --json) e delega para a interface correta.
-Sempre mantenha cli_user.py e cli_mcp.py compatíveis com os mesmos comandos e semântica.
+"""Entry point for the Tribeca Django Init CLI.
+
+The module detects whether automation (MCP) mode is requested via the
+``--json`` flag and delegates to the appropriate interface. Keep
+``cli_user.py`` and ``cli_mcp.py`` synchronized so they support the same
+commands and semantics.
 """
 import sys
 
 if __name__ == "__main__":
-    # Detecta modo MCP (argumentos/flags ou --json)
+    # Detect MCP mode (arguments/flags or --json)
     use_json = any(a == "--json" for a in sys.argv)
-    # Pode ser expandido para detectar outros sinais de automação/MCP
+    # This can be expanded to detect other automation signals
     if use_json:
         from .cli_mcp import main
     else:
         from .cli_user import main
     main()
+

--- a/init_django/templates/backlog.md
+++ b/init_django/templates/backlog.md
@@ -1,62 +1,62 @@
-# 📋 Backlog Estruturado — Tribeca Django Init CLI
+# 📋 Structured Backlog — Tribeca Django Init CLI
 
-## 1. Internacionalização e Localização (Prioridade Alta)
-- [ ] **Pergunta de Idioma Inicial:**  
-  CLI deve perguntar o idioma principal do projeto (`LANGUAGE_CODE`).  
-  Sugerir e documentar: `en`, `pt-br`, `es`, `fr`, `it`, `de`, `zh-cn`, `ja`, `ru`, `ar`.
-- [ ] **Pergunta de Segunda Língua:**  
-  Permitir ao usuário escolher uma segunda língua (`LANGUAGES`).
-- [ ] **Pergunta de TIME_ZONE:**  
-  CLI deve perguntar o fuso horário do projeto (com sugestões).
-- [ ] **Atualização dos Templates:**  
-  Modificar `base.py.tpl` para refletir as escolhas de idioma e timezone.
-- [ ] **Documentação:**  
-  Explicar como funciona a configuração de idiomas e timezone no README.
-- [ ] **Testes Automatizados:**  
-  Testar se as escolhas do usuário são aplicadas corretamente no settings.
+## 1. Internationalization and Localization (High Priority)
+- [ ] **Primary Language Prompt:**
+  The CLI should ask for the project's main language (`LANGUAGE_CODE`). Suggested options: `en`, `pt-br`, `es`, `fr`, `it`, `de`, `zh-cn`, `ja`, `ru`, `ar`.
+- [ ] **Second Language Prompt:**
+  Allow the user to choose a secondary language (`LANGUAGES`).
+- [ ] **TIME_ZONE Prompt:**
+  Ask for the project's time zone (with common suggestions).
+- [ ] **Template Update:**
+  Modify `base.py.tpl` to reflect the chosen language and time zone.
+- [ ] **Documentation:**
+  Explain how language and time zone configuration works in the README.
+- [ ] **Automated Tests:**
+  Ensure the user's choices are correctly applied in the settings.
 
-## 2. Experiência do Usuário no CLI (Prioridade Média)
-- [ ] **Validação de Entradas:**  
-  Validar e sugerir valores padrão/documentados para idioma e timezone.
-- [ ] **Mensagens Contextuais:**  
-  Melhorar prompts e feedbacks do CLI sobre internacionalização.
-- [ ] **Sugestão de Idiomas Populares:**  
-  Auto-completar ou sugerir os idiomas mais comuns ao digitar.
+## 2. CLI User Experience (Medium Priority)
+- [ ] **Input Validation:**
+  Validate and suggest documented defaults for language and time zone.
+- [ ] **Contextual Messages:**
+  Improve CLI prompts and feedback about internationalization.
+- [ ] **Popular Language Suggestions:**
+  Auto-complete or suggest the most common languages as the user types.
 
-## 3. Suporte a Traduções Django (Prioridade Média)
-- [ ] **LOCALE_PATHS:**  
-  Adicionar configuração de `LOCALE_PATHS` no settings.
-- [ ] **Comando para makemessages/compilemessages:**  
-  Adicionar comando opcional no CLI para rodar `django-admin makemessages` e `compilemessages`.
-- [ ] **Exemplo de uso no README:**  
-  Documentar como adicionar novas traduções.
+## 3. Django Translation Support (Medium Priority)
+- [ ] **LOCALE_PATHS:**
+  Add `LOCALE_PATHS` configuration to the settings.
+- [ ] **makemessages/compilemessages Command:**
+  Optionally run `django-admin makemessages` and `compilemessages` via the CLI.
+- [ ] **README Example:**
+  Document how to add new translations.
 
-## 4. Qualidade e Manutenção (Prioridade Baixa)
-- [ ] **Refino dos Templates:**  
-  Revisar e padronizar comentários, docstrings e exemplos nos templates.
-- [ ] **Checklist de Internacionalização:**  
-  Adicionar checklist visual no README para onboarding rápido.
-- [ ] **Sugestão de Ferramentas de Tradução:**  
-  Listar ferramentas recomendadas para tradução colaborativa.
+## 4. Quality and Maintenance (Low Priority)
+- [ ] **Template Refinement:**
+  Review and standardize comments, docstrings, and examples in the templates.
+- [ ] **Internationalization Checklist:**
+  Provide a visual checklist in the README for quick onboarding.
+- [ ] **Translation Tool Suggestions:**
+  List recommended tools for collaborative translation.
 
-## 5. IA, Automação e MCPs (Prioridade Alta)
-- [ ] **Compatibilidade com MCPs (Multi-Component Platforms/AI agents):**
-  Tornar o CLI facilmente integrável e utilizável por plataformas de agentes inteligentes (MCPs), garantindo interoperabilidade e automação.
-- [ ] **Modo Não-Interativo/Automatizável:**
-  Permitir execução do CLI via argumentos/flags para integração com scripts, pipelines e MCPs.
-- [ ] **Prompts e Saídas Estruturadas:**
-  Garantir que todos os prompts e saídas sejam claros, padronizados e facilmente interpretáveis por agentes e MCPs.
-- [ ] **Documentação para Agentes e MCPs:**
-  Adicionar seção no README e AGENTS.md explicando como integrar o CLI com MCPs, exemplos de automação e melhores práticas para agentes.
-- [ ] **Testes Automatizados para Uso por Agentes/MCPs:**
-  Garantir que o CLI funcione bem em ambientes headless, pipelines CI/CD e plataformas MCP.
+## 5. AI, Automation, and MCPs (High Priority)
+- [ ] **Compatibility with MCPs (Multi-Component Platforms/AI agents):**
+  Make the CLI easily integrable with intelligent agent platforms (MCPs), ensuring interoperability and automation.
+- [ ] **Non-Interactive/Automatable Mode:**
+  Allow running the CLI via flags for integration with scripts, pipelines, and MCPs.
+- [ ] **Structured Prompts and Output:**
+  Ensure all prompts and outputs are clear, standardized, and easily interpreted by agents and MCPs.
+- [ ] **Documentation for Agents and MCPs:**
+  Add a section in the README and AGENTS.md explaining how to integrate the CLI with MCPs, including automation examples and best practices.
+- [ ] **Automated Tests for Agent/MCP Usage:**
+  Ensure the CLI works well in headless environments, CI/CD pipelines, and MCP platforms.
 
-## 6. Ideias Futuras e Outras Features
-- [ ] **Suporte a múltiplos ambientes de settings (ex: staging):**
-- [ ] **Geração de arquivos de configuração para CI/CD internacionalizados**
-- [ ] **Integração com serviços de tradução automática**
-- [ ] **Sugestões do usuário**
+## 6. Future Ideas and Other Features
+- [ ] **Support for multiple settings environments (e.g., staging):**
+- [ ] **Generation of internationalized CI/CD configuration files**
+- [ ] **Integration with automatic translation services**
+- [ ] **User suggestions**
 
 ---
 
-> Edite e detalhe este backlog conforme necessário para o roadmap do projeto.
+> Edit and expand this backlog as needed for the project's roadmap.
+


### PR DESCRIPTION
## Summary
- rewrite `docs/mcps_documentation.md` in English
- provide an English backlog template
- translate CLI docstring to English

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b48737cdc83249f5c2b87eb153147