### PR TITLE
Add flake8 config in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ init-django = "init_django.cli:main"
 
 [tool.pip.install]
 post-install = "scripts/post_install.py"
+
+[tool.flake8]
+max-line-length = 88


### PR DESCRIPTION
## Summary
- extend `pyproject.toml` with a `[tool.flake8]` block to define `max-line-length = 88`

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4b64b65c8324bcc492d602a83a5c