### PR TITLE
Fix CLI import order and line breaks

### DIFF
--- a/init_django/cli_mcp.py
+++ b/init_django/cli_mcp.py
@@ -2,14 +2,15 @@
 Always keep command compatibility and semantics in sync with ``cli_user.py``.
 """
 
-from pathlib import Path
-import click
-from init_django import print_install_success
-from init_django.cli_common import TEMPLATES_DIR, emit_json_event, run
-
 import os
 import sys
+from pathlib import Path
 from shutil import copyfile
+
+import click
+
+from init_django import print_install_success
+from init_django.cli_common import TEMPLATES_DIR, emit_json_event, run
 
 
 @click.command()

--- a/init_django/cli_user.py
+++ b/init_django/cli_user.py
@@ -2,13 +2,14 @@
 Always keep command compatibility and semantics in sync with ``cli_mcp.py``.
 """
 
+import os
 from pathlib import Path
+from shutil import copyfile
+
 import click
+
 from init_django import print_install_success
 from init_django.cli_common import TEMPLATES_DIR, run
-
-import os
-from shutil import copyfile
 
 
 @click.command()


### PR DESCRIPTION
## Summary
- tweak multiline print lines in `print_install_success`
- tighten `cli_common` docstring spacing
- reorder imports in CLI modules for consistency
- run tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b524c851083248c6d6c18af59fe35