### PR TITLE
Consolidate CLI docs and fix tests

### DIFF
--- a/init_django/cli_common.py
+++ b/init_django/cli_common.py
@@ -1,6 +1,7 @@
 """Utility functions and shared logic for both CLI interfaces (user and MCP).
-Whenever a command is added or modified, ensure ``cli_user.py`` and
-``cli_mcp.py`` remain compatible with the same API and semantics.
+
+Whenever a command is added or modified, ensure ``cli_user.py`` and ``cli_mcp.py``
+remain compatible with the same API and semantics.
 """
 
 import json

--- a/init_django/templates/agents.md.tpl
+++ b/init_django/templates/agents.md.tpl
@@ -146,7 +146,7 @@ class MyModelViewSet(viewsets.ModelViewSet):
 - Use Flower for monitoring.
 - Write tests for asynchronous tasks.
 
-Exemplo de task Celery:
+Celery task example:
 
 ```python
 from celery import shared_task

--- a/init_django/templates/docs/django_models_template.md
+++ b/init_django/templates/docs/django_models_template.md
@@ -71,13 +71,13 @@ class Setting(models.Model):
     """
     System configuration for the accounts app.
     """
-    ref = models.CharField(max_length=50, unique=True, verbose_name='Referência')
-    description = models.TextField(verbose_name='Descrição')
-    val = models.TextField(null=True, blank=True, verbose_name='Valor')
+    ref = models.CharField(max_length=50, unique=True, verbose_name='Reference')
+    description = models.TextField(verbose_name='Description')
+    val = models.TextField(null=True, blank=True, verbose_name='Value')
 
     class Meta:
-        verbose_name = 'Configuração Accounts'
-        verbose_name_plural = 'Configurações Accounts'
+        verbose_name = 'Accounts Setting'
+        verbose_name_plural = 'Accounts Settings'
         ordering = ['description']
 
     def __str__(self):
@@ -114,13 +114,13 @@ class SettingWebsite(models.Model):
     """
     System configuration for the website app.
     """
-    ref = models.CharField(max_length=50, unique=True, verbose_name='Referência')
-    description = models.TextField(verbose_name='Descrição')
-    val = models.TextField(null=True, blank=True, verbose_name='Valor')
+    ref = models.CharField(max_length=50, unique=True, verbose_name='Reference')
+    description = models.TextField(verbose_name='Description')
+    val = models.TextField(null=True, blank=True, verbose_name='Value')
 
     class Meta:
-        verbose_name = 'Configuração Website'
-        verbose_name_plural = 'Configurações Website'
+        verbose_name = 'Website Setting'
+        verbose_name_plural = 'Website Settings'
         ordering = ['description']
 
     def __str__(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,17 @@
 import json
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
-import pytest
-from click.testing import CliRunner
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from init_django.cli_mcp import main as mcp_main
-from init_django.cli_user import main
+import pytest  # noqa: E402
+from click.testing import CliRunner  # noqa: E402
+
+from init_django.cli_mcp import main as mcp_main  # noqa: E402
+from init_django.cli_user import main  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- update docstring formatting for shared CLI utilities
- clarify Celery example wording for agents
- update English wording in docs template
- adjust test imports so module resolves correctly

## Testing
- `pre-commit run --files init_django/cli_common.py init_django/templates/agents.md.tpl init_django/templates/docs/django_models_template.md tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5e8d525c832483556d0e70e6319e