### PR TITLE
Add unified DevOps guide and update tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --cov=init_django --cov-report=xml --maxfail=1 --disable-warnings -v
+          pytest --cov=init_django --cov-report=xml --cov-fail-under=90 --maxfail=1 --disable-warnings -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,17 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--ignore-missing-imports"]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest (smoke)
+        entry: pytest
+        language: system
+        pass_filenames: false
+        types: [python]
+        args: ["-k", "test_cli"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,13 @@ The Tribeca Django Init CLI is being designed for streamlined use by intelligent
 - All documentation and templates are now in English
 - Docs folder standardized: api_documentation.md, architecture_blueprint.md, django_models_template.md
 - README and AGENTS.md reference all docs and explain project standards
+
+## [2025-06-26] Unified Development & Operations Guide Added
+- Added `docs/unified_dev_ops_guide.md` consolidating shell, Python/Django and CI/CD practices.
+- Referenced the new guide in README and this AGENTS file.
 ```
 
 ## References
 - Always keep this file and the README.md up to date with any relevant change.
 - For detailed technical standards, see the files in `docs/`.
+- See [`docs/unified_dev_ops_guide.md`](docs/unified_dev_ops_guide.md) for the unified development and operations standards.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Support and compatibility with MCPs is already under active planning. See detail
 
 - [README](README.md): this file
 - [AGENTS.md](AGENTS.md): standards & automation for humans and AI
+- [docs/unified_dev_ops_guide.md](docs/unified_dev_ops_guide.md): unified development & operations guide
 - [docs/](init_django/templates/docs/): API, architecture, and models templates
 
 ---

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
+########################################################################
+# Script Name: cleanup.sh
+# Version: 1.0.0
+# Date: 2025-06-26
+# Author: Tribeca Team
+# Description: Remove temporary build, test and crawl artifacts.
+# Usage: ./cleanup.sh
+# Exit codes: 0 (OK) | 1 (Error)
+# Prerequisites: Unix-like OS, standard shell utilities
+# Steps: 1. Remove predefined patterns
+# See Also: docs/unified_dev_ops_guide.md
+########################################################################
 set -euo pipefail
+
+echo "[INFO][$(date '+%Y-%m-%d %H:%M:%S')] Starting cleanup" 
 
 # Remove Python build/test artifacts
 declare -a patterns=(
@@ -14,4 +28,4 @@ for p in "${patterns[@]}"; do
   rm -rf $p 2>/dev/null || true
 done
 
-printf "Temporary build, test, and crawl artifacts cleaned.\n"
+echo "[INFO][$(date '+%Y-%m-%d %H:%M:%S')] Temporary build, test, and crawl artifacts cleaned."

--- a/docs/unified_dev_ops_guide.md
+++ b/docs/unified_dev_ops_guide.md
@@ -1,0 +1,100 @@
+# Unified Development and Operations Guide
+
+This guide consolidates recommended practices for shell scripts, Python/Django projects, and CI/CD workflows. It serves as a reference for both human developers and AI agents working on Tribeca Django Init.
+
+## 1. Principles
+- **Clean Code**
+- **Modularity**
+- **Living Documentation**
+- **Security by Design**
+- **Performance Awareness**
+
+## 2. Shell Scripts
+
+### 2.1 Standard Header
+Include the following metadata block at the top of every shell script:
+```bash
+########################################################################
+# Script Name: <name>
+# Version: x.y.z
+# Date: YYYY-MM-DD
+# Author: <team>
+# Description: <purpose>
+# Usage: <examples>
+# Exit codes: 0 (OK) | 1 (Error)
+# Prerequisites: OS, dependencies, root
+# Steps: 1. …
+# See Also: useful links
+########################################################################
+```
+
+### 2.2 Size Limits
+| Item  | Limit |
+|-------|-------|
+| File  | ≤ 600 lines |
+| Refactor starting from | 400 lines |
+| AI chunk | ≤ 300 lines |
+
+### 2.3 Safe Flow
+- Always enable `set -e`.
+- Validate prerequisites.
+- Create backups or rollback steps before destructive actions.
+
+### 2.4 Comments
+- Briefly describe each logical block.
+- Use `[INFO][YYYY-MM-DD HH:MM:SS]` messages for progress logs.
+
+## 3. Python/Django Projects
+
+### 3.1 Conventions
+- Python ≥ 3.10.
+- PEP 8 style with Black (88 char line length).
+- `snake_case` for functions and variables, `PascalCase` for classes.
+- Full type annotations (PEP 484/526).
+
+### 3.2 Limits
+| Item  | Limit |
+|-------|-------|
+| File  | ≤ 500 lines |
+| Refactor starting from | 300 lines |
+| AI chunk | ≤ 200 lines |
+
+### 3.3 Module Structure
+- One module per objective.
+- One function per action.
+- Use `async/await` when needed.
+
+### 3.4 Docstrings
+```python
+def clean_text(text: str) -> str:
+    """Remove undesired characters and extra spaces."""
+```
+
+### 3.5 Tests
+```bash
+pytest tests/
+pytest --cov=tribeca_insights  # minimum 90% coverage
+```
+
+### 3.6 Pull Requests
+1. Objective description and related issue.
+2. One logical change per PR.
+3. All checks must pass.
+
+### 3.7 Pre-commit (mandatory)
+Configure `.pre-commit-config.yaml` with:
+1. `black`
+2. `isort`
+3. `flake8`
+4. `mypy` (optional)
+5. `pytest` (smoke)
+
+Failures block commits.
+
+## 4. CI/CD
+- Run lint, tests, and coverage in pull requests.
+- Block merge when coverage < 90%.
+- Enable secret scanning.
+
+## 5. Updates
+Include all new practices in this guide via documentation pull requests.


### PR DESCRIPTION
## Summary
- document unified development and operations practices
- reference the new guide in README and AGENTS docs
- extend pre-commit with mypy and pytest smoke tests
- enforce 90% coverage in CI
- add metadata header and logging to cleanup script

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6a6d6f1483249400108eddcc1efe