### PR TITLE
Improve CLI typing per Unified DevOps guide

### DIFF
--- a/init_django/cli_mcp.py
+++ b/init_django/cli_mcp.py
@@ -6,6 +6,7 @@ import os
 import sys
 from pathlib import Path
 from shutil import copyfile
+from typing import Optional
 
 import click
 
@@ -31,18 +32,18 @@ from init_django.cli_common import TEMPLATES_DIR, emit_json_event, run
 @click.option("--migrate", type=click.Choice(["yes", "no"]), default=None)
 @click.option("--readme", type=click.Choice(["yes", "no"]), default=None)
 def main(
-    json_mode,
-    venv,
-    install_deps,
-    django_version,
-    git_init,
-    project,
-    settings,
-    app_name,
-    app_create,
-    migrate,
-    readme,
-):
+    json_mode: bool,
+    venv: Optional[str],
+    install_deps: Optional[str],
+    django_version: Optional[str],
+    git_init: Optional[str],
+    project: Optional[str],
+    settings: Optional[str],
+    app_name: Optional[str],
+    app_create: Optional[str],
+    migrate: Optional[str],
+    readme: Optional[str],
+) -> None:
     """MCP/agent CLI: non-interactive, argument-driven, emits JSON."""
     try:
         print_install_success()
@@ -153,14 +154,17 @@ def main(
                 )
             elif settings == "yes":
                 os.makedirs(settings_dir)
-                for f in ["base.py", "dev.py", "prod.py"]:
-                    copyfile(TEMPLATES_DIR / "settings" / f"{f}.tpl", settings_dir / f)
-                with open(settings_dir / "__init__.py", "w") as f:
-                    f.write("from .dev import *  # default to dev")
-                with open(base / "config" / "wsgi.py", "r+") as f:
-                    content = f.read()
-                    f.seek(0)
-                    f.write(content.replace("config.settings", "config.settings.dev"))
+                for fname in ["base.py", "dev.py", "prod.py"]:
+                    copyfile(
+                        TEMPLATES_DIR / "settings" / f"{fname}.tpl",
+                        settings_dir / fname,
+                    )
+                with open(settings_dir / "__init__.py", "w") as fh:
+                    fh.write("from .dev import *  # default to dev")
+                with open(base / "config" / "wsgi.py", "r+") as fh:
+                    content = fh.read()
+                    fh.seek(0)
+                    fh.write(content.replace("config.settings", "config.settings.dev"))
                 emit_json_event(
                     "settings",
                     "success",

--- a/init_django/cli_user.py
+++ b/init_django/cli_user.py
@@ -13,7 +13,7 @@ from init_django.cli_common import TEMPLATES_DIR, run
 
 
 @click.command()
-def main():
+def main() -> None:
     """Interactive CLI to bootstrap Django projects following best practices."""
     print_install_success()
     base = Path.cwd()
@@ -140,16 +140,17 @@ def main():
                 )
                 if settings_choice == "1":
                     os.makedirs(settings_dir)
-                    for f in ["base.py", "dev.py", "prod.py"]:
+                    for fname in ["base.py", "dev.py", "prod.py"]:
                         copyfile(
-                            TEMPLATES_DIR / "settings" / f"{f}.tpl", settings_dir / f
+                            TEMPLATES_DIR / "settings" / f"{fname}.tpl",
+                            settings_dir / fname,
                         )
-                    with open(settings_dir / "__init__.py", "w") as f:
-                        f.write("from .dev import *  # default to dev")
-                    with open(base / "config" / "wsgi.py", "r+") as f:
-                        content = f.read()
-                        f.seek(0)
-                        f.write(
+                    with open(settings_dir / "__init__.py", "w") as fh:
+                        fh.write("from .dev import *  # default to dev")
+                    with open(base / "config" / "wsgi.py", "r+") as fh:
+                        content = fh.read()
+                        fh.seek(0)
+                        fh.write(
                             content.replace("config.settings", "config.settings.dev")
                         )
                 else:


### PR DESCRIPTION
## Summary
- add explicit type hints for `cli_mcp.main` and `cli_user.main`
- rename local variables used for file handles to satisfy mypy

## Testing
- `black init_django/cli_user.py init_django/cli_mcp.py`
- `isort init_django/cli_user.py init_django/cli_mcp.py`
- `flake8 init_django/cli_user.py init_django/cli_mcp.py`
- `mypy init_django/cli_user.py init_django/cli_mcp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7062a3f88324b0e5241d3ea783f4