### PR TITLE
Add env file helper and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ README.md
 
 ### Environment Variables & django-environ
 - The project uses [django-environ](https://django-environ.readthedocs.io/) for configuration.
-- Create a `.env` file in your project root (see `.env.example` for guidance).
+- The CLI can automatically copy `.env.example` to `.env` after project creation.
+- You can also manually create the file if preferred.
 - Typical variables:
   - `DJANGO_SECRET_KEY`, `DEBUG`, `DJANGO_ALLOWED_HOSTS`, `DATABASE_URL`, etc.
 - This approach keeps secrets and environment-specific config out of version control and enables safe, Twelve-Factor deployments.

--- a/init_django/cli_common.py
+++ b/init_django/cli_common.py
@@ -184,3 +184,12 @@ def create_readme(base: Path) -> None:
     """Create ``README.md`` from the packaged template."""
 
     copyfile(TEMPLATES_DIR / "readme.md.tpl", base / "README.md")
+
+
+def create_env_file(base: Path) -> None:
+    """Copy ``.env.example`` to ``.env`` in ``base`` if missing."""
+
+    src = TEMPLATES_DIR / ".env.example"
+    dest = base / ".env"
+    if not dest.exists() and src.exists():
+        copyfile(src, dest)

--- a/init_django/cli_mcp.py
+++ b/init_django/cli_mcp.py
@@ -15,6 +15,7 @@ from init_django.cli_common import (
     apply_migrations,
     create_app,
     create_readme,
+    create_env_file,
     create_settings_package,
     create_virtualenv,
     emit_json_event,
@@ -42,6 +43,7 @@ from init_django.cli_common import (
 @click.option("--app-create", type=click.Choice(["yes", "no"]), default=None)
 @click.option("--migrate", type=click.Choice(["yes", "no"]), default=None)
 @click.option("--readme", type=click.Choice(["yes", "no"]), default=None)
+@click.option("--env-file", type=click.Choice(["yes", "no"]), default=None)
 def main(
     json_mode: bool,
     venv: Optional[str],
@@ -54,6 +56,7 @@ def main(
     app_create: Optional[str],
     migrate: Optional[str],
     readme: Optional[str],
+    env_file: Optional[str],
 ) -> None:
     """MCP/agent CLI: non-interactive, argument-driven, emits JSON."""
     try:
@@ -192,6 +195,25 @@ def main(
                 )
             else:
                 emit_json_event("readme", "skipped", "Skipped README creation", {})
+
+            # .env file
+            if (base / ".env").exists():
+                emit_json_event(
+                    "env_file",
+                    "success",
+                    ".env already exists",
+                    {"path": str(base / ".env")},
+                )
+            elif env_file == "yes":
+                create_env_file(base)
+                emit_json_event(
+                    "env_file",
+                    "success",
+                    ".env created from template",
+                    {"path": str(base / ".env")},
+                )
+            else:
+                emit_json_event("env_file", "skipped", "Skipped .env creation", {})
         else:
             emit_json_event("project", "skipped", "Skipped Django project creation", {})
         emit_json_event(

--- a/init_django/cli_user.py
+++ b/init_django/cli_user.py
@@ -13,6 +13,7 @@ from init_django.cli_common import (
     apply_migrations,
     create_app,
     create_readme,
+    create_env_file,
     create_settings_package,
     create_virtualenv,
     initialize_git,
@@ -169,6 +170,20 @@ def main() -> None:
             else:
                 create_readme(base)
                 click.echo("README.md created from template.")
+
+            if (base / ".env").exists():
+                click.echo(".env already exists.")
+            else:
+                env_choice = click.prompt(
+                    "8️⃣  Create .env from .env.example?\n1️⃣  Create file\n2️⃣  Skip this step\nEnter your choice:",
+                    type=click.Choice(["1", "2"]),
+                    default="1",
+                )
+                if env_choice == "1":
+                    create_env_file(base)
+                    click.echo(".env file created from template.")
+                else:
+                    click.echo("Skipping .env creation.")
         else:
             click.echo("Skipping Django project creation.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ def test_cli_basic_flow(temp_project_dir, monkeypatch):
         "users",  # App name
         "1",  # Create app
         "1",  # Apply migrations
+        "1",  # Create .env file
     ]
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test-key")
     result = runner.invoke(main, input="\n".join(inputs) + "\n")
@@ -54,6 +55,7 @@ def test_cli_basic_flow(temp_project_dir, monkeypatch):
     assert (temp_project_dir / "config" / "settings" / "base.py").exists()
     assert (temp_project_dir / "config" / "settings" / "dev.py").exists()
     assert (temp_project_dir / "config" / "settings" / "prod.py").exists()
+    assert (temp_project_dir / ".env").exists()
 
 
 def test_cli_skip_steps(temp_project_dir, monkeypatch):
@@ -70,6 +72,7 @@ def test_cli_skip_steps(temp_project_dir, monkeypatch):
         "users",  # App name
         "2",  # Skip app
         "2",  # Skip migrations
+        "2",  # Skip .env file
     ]
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test-key")
     result = runner.invoke(main, input="\n".join(inputs) + "\n")
@@ -93,6 +96,7 @@ def test_cli_custom_app_name(temp_project_dir, monkeypatch):
         app_name,  # app name
         "1",  # create app
         "1",  # migrations
+        "1",  # create .env file
     ]
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test-key")
     result = runner.invoke(main, input="\n".join(inputs) + "\n")
@@ -100,6 +104,7 @@ def test_cli_custom_app_name(temp_project_dir, monkeypatch):
     assert (temp_project_dir / app_name).exists() or (
         temp_project_dir / f"{app_name}"
     ).exists()
+    assert (temp_project_dir / ".env").exists()
 
 
 def test_cli_mcp_json_output(temp_project_dir):
@@ -126,6 +131,8 @@ def test_cli_mcp_json_output(temp_project_dir):
             "--migrate",
             "no",
             "--readme",
+            "no",
+            "--env-file",
             "no",
         ],
     )
@@ -175,6 +182,8 @@ def test_cli_requires_dependencies_mcp(temp_project_dir):
             "--migrate",
             "no",
             "--readme",
+            "no",
+            "--env-file",
             "no",
         ],
     )


### PR DESCRIPTION
## Summary
- add `create_env_file` helper to copy `.env.example`
- prompt to create `.env` in interactive mode
- add `--env-file` flag for MCP/agent mode
- update README docs about env file creation
- adjust tests for new prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c557a4cac832493ace1949d413e25