### PR TITLE
fix package discovery for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ max-line-length = 88
 
 [tool.isort]
 profile = "black"
+
+[tool.setuptools]
+packages = ["init_django"]


### PR DESCRIPTION
## Summary
- tweak packaging setup for editable mode

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -k test_cli -q`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_686c8afef5f48324b0d5be265e2c80cc