### PR TITLE
Update CI to pin pip and setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==24.0 setuptools==68.2.2
           pip install -e .
           pip install pytest pytest-cov pre-commit
       - name: Configure Git


### PR DESCRIPTION
## Summary
- pin pip and setuptools versions in the CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -k test_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8bc8ae008324be96762401bb2692