### PR TITLE
Fix cleanup.sh quoting

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -25,7 +25,7 @@ declare -a patterns=(
 )
 
 for p in "${patterns[@]}"; do
-  rm -rf $p 2>/dev/null || true
+  rm -rf "$p" 2>/dev/null || true
 done
 
 echo "[INFO][$(date '+%Y-%m-%d %H:%M:%S')] Temporary build, test, and crawl artifacts cleaned."


### PR DESCRIPTION
## Summary
- quote pattern variable when removing artifacts

## Testing
- `pre-commit run --files cleanup.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c8d163908832482643d9cc97e40ab