### PR TITLE
Add pre-commit check for review index

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
         args: ["--ignore-missing-imports"]
   - repo: local
     hooks:
+      - id: check-review-index
+        name: review index updated
+        entry: python scripts/check_review_index.py
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest (smoke)
         entry: pytest

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ pre-commit run --all-files
 
 The hooks will format and lint your code automatically before each commit.
 These style checks also run in the CI workflow to keep contributions consistent.
+The setup also checks if `review/indexReview.md` was modified. Always registre
+suas revisões no topo desse arquivo antes de commitar.
 
 ---
 

--- a/review/indexReview.md
+++ b/review/indexReview.md
@@ -14,4 +14,5 @@ Utilize o modelo de tabela abaixo e adicione novas linhas **acima** das existent
 
 | Data | Problema | Solução | Takeaway | Link |
 | ---- | -------- | --------- | -------- | ---- |
+| 2025-07-08 | Checagem automática do índice | Script `check_review_index` no pre-commit | Lembrar de atualizar sempre | Este commit |
 | 2025-07-09 | Processo de revisão criado | Adicionada tabela em `indexReview.md` | Manter revisões sempre atualizadas antes dos commits | Este arquivo |

--- a/scripts/check_review_index.py
+++ b/scripts/check_review_index.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to ensure review/indexReview.md is updated."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+INDEX_PATH = Path("review/indexReview.md")
+
+
+def review_index_modified() -> bool:
+    """Return True if the review index is staged for commit."""
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    staged_files = result.stdout.splitlines()
+    return str(INDEX_PATH) in staged_files
+
+
+def main() -> None:
+    if not review_index_modified():
+        print(
+            "❌  review/indexReview.md não foi atualizado.\n"
+            "🚨  Atualize o índice de revisões antes de realizar o commit.\n"
+            "ℹ️  Consulte review/indexReview.md e AGENTS.md para detalhes."
+        )
+        sys.exit(1)
+    print("✅  Index de revisões atualizado. Obrigado por manter o histórico!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure `review/indexReview.md` gets updated via new `check_review_index.py`
- run the new script as a pre-commit hook
- document the automatic review index check in the README
- note new review entry

## Testing
- `pre-commit run --files scripts/check_review_index.py README.md .pre-commit-config.yaml review/indexReview.md`

------
https://chatgpt.com/codex/tasks/task_e_686c8d669e9c8324ac317ad191779191